### PR TITLE
Dynamic Emoji for Starboard

### DIFF
--- a/src/events/star.rs
+++ b/src/events/star.rs
@@ -123,7 +123,10 @@ impl EventHandler for StarHandler {
             .await;
 
         // If the message has enough stars, send it to the starboard
-        if data.stars.len() == MIN_STARS && data.starboard_id.is_none() {
+        let mut stars = data.stars.clone();
+        stars.sort();
+        stars.dedup();
+        if stars.len() == MIN_STARS && data.starboard_id.is_none() {
             // Message has just reached starboard threshold
             let embed = make_starboard_embed(&reaction_message, &emoji);
 
@@ -140,16 +143,13 @@ impl EventHandler for StarHandler {
                 .update_starboard_message(data._id, message.id.into())
                 .await;
             // channel.say(&ctx.http, embed).await.unwrap();
-        } else if data.stars.len() >= MIN_STARS {
+        } else if stars.len() >= MIN_STARS {
             // Edit the starboard message to reflect the new amount of stars
             let mut message = channel
                 .message(&ctx.http, data.starboard_id.unwrap() as u64)
                 .await
                 .unwrap();
             let mut embed = message.embeds.first().unwrap().clone();         
-            let mut stars = data.stars.clone();
-            stars.sort();
-            stars.dedup();
             embed.title = Some(format!("{} {}", stars.len(), emoji));
             message
                 .edit(&ctx.http, EditMessage::new().embed(embed.into()))

--- a/src/events/star.rs
+++ b/src/events/star.rs
@@ -137,7 +137,10 @@ impl EventHandler for StarHandler {
                 .await
                 .unwrap();
             let mut embed = message.embeds.first().unwrap().clone();         
-            embed.title = Some(format!("{} {}", data.stars.len(), emoji));
+            let mut stars = data.stars.clone();
+            stars.sort();
+            stars.dedup();
+            embed.title = Some(format!("{} {}", stars.len(), emoji));
             message
                 .edit(&ctx.http, EditMessage::new().embed(embed.into()))
                 .await
@@ -181,7 +184,10 @@ impl EventHandler for StarHandler {
             .unwrap();
         let mut embed = message.embeds.first().unwrap().clone();
         let emoji = if reaction.emoji == ReactionType::Unicode("⭐".to_string()) { "🌟" } else { "💀" };          
-        embed.title = Some(format!("{} {}", data.unwrap().stars.len(), emoji));
+        let mut stars = data.unwrap().stars.clone();
+        stars.sort();
+        stars.dedup();
+        embed.title = Some(format!("{} {}", stars.len(), emoji));
         message
             .edit(&ctx.http, EditMessage::new().embed(embed.into()))
             .await

--- a/src/structures/starboard.rs
+++ b/src/structures/starboard.rs
@@ -76,7 +76,11 @@ impl Starboard {
             .iter()
             .map(|x| x.as_i64().unwrap())
             .collect::<Vec<i64>>();
-        stars.retain(|x| *x != user_id);
+
+        // Remove only one instance of the user_id to allow for different emojis
+        if let Some(pos) = stars.iter().position(|x| *x == user_id) {
+            stars.remove(pos);
+        }
 
         let star_struct = StarStruct {
             _id: id,


### PR DESCRIPTION
Too many good messages get lost because people decide to react with a more relevant emoji than a ⭐.

Allows for any emoji to be used for starboard reactions. Initially just for 💀 but then what about 🔥, 😭 or even 👍?
- Changes emoji used on board to most common reaction to message
- Only counts each user once
- All reactions add to total

_May lead to a need to increase MIN_REACTIONS threshold_